### PR TITLE
Suggestion: change waitlist from class to mixin

### DIFF
--- a/app/models/signup_topic.rb
+++ b/app/models/signup_topic.rb
@@ -1,4 +1,6 @@
 class SignupTopic < ApplicationRecord
+  include Waitlist
+
   belongs_to :assignment
   has_many :signed_up_teams, counter_cache: true
 
@@ -28,7 +30,7 @@ class SignupTopic < ApplicationRecord
       end
       if !maxChoosers.nil? && maxChoosers > self.max_choosers
         count_teams_to_promote = maxChoosers - self.max_choosers
-        Waitlist.promote_teams_from_waitlist(self.id, count_teams_to_promote)
+        SignupTopic.promote_teams_from_waitlist(self.id, count_teams_to_promote)
         self.max_choosers = maxChoosers
         need_to_update = true
       end
@@ -54,7 +56,7 @@ class SignupTopic < ApplicationRecord
   # Method used to promote 1 team from waitlist if there a signed up team is deleted.
   def release_team
     self.transaction do
-      return Waitlist.promote_teams_from_waitlist(self.id)
+      return SignupTopic.promote_teams_from_waitlist(self.id)
     end
   end
 

--- a/app/models/waitlist.rb
+++ b/app/models/waitlist.rb
@@ -1,23 +1,28 @@
-class Waitlist
-  
-  # This method returns the count of teams in the waitlist for the given topic.
-  def self.count_waitlisted_teams(topic_id)
-    return SignedUpTeam.where(signup_topic_id: topic_id, is_waitlisted: true).count
+module Waitlist
+  def self.included base
+    base.extend WaitlistMethods
   end
-  
-  # This method chooses the first N teams in the waitlist for promotion and delete them from the waitlist. The teams are sorted in ascending order based on the creation date in order to prioritize the teams that were put on the waitlist ahead of others.
-  def self.promote_teams_from_waitlist(topic_id, count=1)
-    promotable_teams = SignedUpTeam.where(signup_topic_id: topic_id, is_waitlisted: true).limit(count).order('created_at asc');
-
-    promoted_ids = promotable_teams.pluck(:id)
+ 
+  module WaitlistMethods
+    # This method returns the count of teams in the waitlist for the given topic.
+    def count_waitlisted_teams(topic_id)
+      return SignedUpTeam.where(signup_topic_id: topic_id, is_waitlisted: true).count
+    end
     
-    promotable_teams.update_all({:is_waitlisted => false})
+    # This method chooses the first N teams in the waitlist for promotion and delete them from the waitlist. The teams are sorted in ascending order based on the creation date in order to prioritize the teams that were put on the waitlist ahead of others.
+    def promote_teams_from_waitlist(topic_id, count=1)
+      promotable_teams = SignedUpTeam.where(signup_topic_id: topic_id, is_waitlisted: true).limit(count).order('created_at asc');
 
-    return promoted_ids
-  end
+      promoted_ids = promotable_teams.pluck(:id)
+      
+      promotable_teams.update_all({:is_waitlisted => false})
 
-  # Returns the IDs of the teams which are on the waitlist for the chosen topic.
-  def self.get_waitlisted_teams(topic_id)
-    return SignedUpTeam.where(signup_topic_id: topic_id).pluck(:id)
+      return promoted_ids
+    end
+
+    # Returns the IDs of the teams which are on the waitlist for the chosen topic.
+    def get_waitlisted_teams(topic_id)
+      return SignedUpTeam.where(signup_topic_id: topic_id).pluck(:id)
+    end
   end
 end

--- a/app/serializers/signup_topic_serializer.rb
+++ b/app/serializers/signup_topic_serializer.rb
@@ -2,7 +2,7 @@ class SignupTopicSerializer
   include JSONAPI::Serializer
   attributes :id, :name, :category, :topic_identifier, :description, :link
   attributes :num_waitlisted do |object|
-    Waitlist.count_waitlisted_teams(object.id)
+    SignupTopic.count_waitlisted_teams(object.id)
   end
   attributes :available_slots do |object|
     object.count_available_slots

--- a/spec/models/signed_up_team_spec.rb
+++ b/spec/models/signed_up_team_spec.rb
@@ -30,12 +30,12 @@ RSpec.describe SignedUpTeam, type: :model do
     it "Waitlists a team for the topic if the topic is not available and checks if the record exists in the database" do
       expect(SignedUpTeam.create_signed_up_team(topic["id"], team["id"])).to be true
       
-      expect(Waitlist.count_waitlisted_teams(topic["id"])).to eq(0)
+      expect(SignupTopic.count_waitlisted_teams(topic["id"])).to eq(0)
       
       team2 = Team.create
       expect(SignedUpTeam.create_signed_up_team(topic["id"], team2["id"])).to be true
 
-      expect(Waitlist.count_waitlisted_teams(topic["id"])).to eq(1)
+      expect(SignupTopic.count_waitlisted_teams(topic["id"])).to eq(1)
     end
 
     it 'Creates a signed up team if the topic is available and checks the count increment in the database' do

--- a/spec/models/waitlist_spec.rb
+++ b/spec/models/waitlist_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Waitlist, type: :model do
     it "returns count of teams waitlisted for given topic" do
       expect(waitlisted_team).to be_valid
 
-      actual_count_for_topic = Waitlist.count_waitlisted_teams(topic["id"])
+      actual_count_for_topic = SignupTopic.count_waitlisted_teams(topic["id"])
       expected_count_for_topic = 1
       expect(actual_count_for_topic).to eq(expected_count_for_topic)
     end
@@ -24,7 +24,7 @@ RSpec.describe Waitlist, type: :model do
     it "gets the waitlisted teams" do
       expect(waitlisted_team).to be_valid
 
-      teams = Waitlist.get_waitlisted_teams(topic["id"])
+      teams = SignupTopic.get_waitlisted_teams(topic["id"])
       expect(teams).to include(waitlisted_team["id"])
     end
 
@@ -32,11 +32,11 @@ RSpec.describe Waitlist, type: :model do
     it "Promotes waitlisted teams" do
       expect(waitlisted_team).to be_valid
 
-      actual_promoted_teams = Waitlist.promote_teams_from_waitlist(topic["id"])
+      actual_promoted_teams = SignupTopic.promote_teams_from_waitlist(topic["id"])
 
       expect(actual_promoted_teams).to include(waitlisted_team["id"])
 
-      waitlist_count = Waitlist.count_waitlisted_teams(topic["id"])
+      waitlist_count = SignupTopic.count_waitlisted_teams(topic["id"])
       expect(waitlist_count).to eq(0)
     end
   end
@@ -48,7 +48,7 @@ RSpec.describe Waitlist, type: :model do
       expect(waitlisted_team).to be_valid
 
       non_existent_topic = 2
-      actual_count_for_topic = Waitlist.count_waitlisted_teams(non_existent_topic)
+      actual_count_for_topic = SignupTopic.count_waitlisted_teams(non_existent_topic)
       expected_count_for_topic = 0
       expect(actual_count_for_topic).to eq(expected_count_for_topic)
     end
@@ -58,7 +58,7 @@ RSpec.describe Waitlist, type: :model do
       expect(waitlisted_team).to be_valid
 
       non_existent_topic = 2
-      teams = Waitlist.get_waitlisted_teams(non_existent_topic)
+      teams = SignupTopic.get_waitlisted_teams(non_existent_topic)
       expect(teams).to_not include(waitlisted_team["id"])
       expect(teams).to_not include(non_waitlisted_team["id"])
     end
@@ -67,11 +67,11 @@ RSpec.describe Waitlist, type: :model do
     it "checks if promotion of different topic does not modify other topic waitlist" do
       expect(waitlisted_team).to be_valid
 
-      actual_promoted_teams = Waitlist.promote_teams_from_waitlist(2)
+      actual_promoted_teams = SignupTopic.promote_teams_from_waitlist(2)
 
       expect(actual_promoted_teams).to_not include(waitlisted_team["id"])
 
-      waitlist_count = Waitlist.count_waitlisted_teams(topic["id"])
+      waitlist_count = SignupTopic.count_waitlisted_teams(topic["id"])
       expect(waitlist_count).to eq(1)
     end
   end


### PR DESCRIPTION
As per review demo comments, updated the Waitlist class to convert it to a mixin module instead of a standalone class. The functionality is offered as a part of the SignupTopic class.